### PR TITLE
Added Caching For Commonly Pulled FireStore Docs

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.6.1"
+  firestore_cache:
+    dependency: "direct main"
+    description:
+      name: firestore_cache
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.0+1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -548,6 +555,55 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
   image_picker: ^0.8.7+5
   sanitize_filename: ^1.0.5
   loader_overlay: ^2.2.0
+  firestore_cache: ^2.3.0+1
+  shared_preferences: ^2.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Caches commonly accessed FireStore documents using a `lastUpdated` field on a separate FireStore document, before accessing and pulling identical data.